### PR TITLE
Fix failling to import models

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,3 +1,3 @@
 from .treehouse import TreeHouseClient
 from .client import TreeHouseAPI
-import models
+from .models import *


### PR DESCRIPTION
When I executed `python main.py`, an error was thrown saying
```
Traceback (most recent call last):
  File "main.py", line 3, in <module>
    from api import TreeHouseClient, TreeHouseAPI
  File "/Treehouse-Video-Downloader/api/__init__.py", line 3, in <module>
    import tracking.models
ImportError: No module named 'tracking'
```

So I changed the way of importing from `import models` to `from .models import *` in `./api/__init__.py`, and now it's perfectly working.